### PR TITLE
Add CoX Shamans, Mystics, Vasa

### DIFF
--- a/src/main/java/com/example/enemydata/Enemy.java
+++ b/src/main/java/com/example/enemydata/Enemy.java
@@ -75,11 +75,6 @@ public abstract class Enemy implements IEnemy {
 
         bosses.add(NpcID.ABYSSAL_PORTAL);
         bosses.add(NpcID.VASA_NISTIRIO);
-        bosses.add(NpcID.LIZARDMAN_SHAMAN_7573);
-        bosses.add(NpcID.LIZARDMAN_SHAMAN_7574);
-        bosses.add(NpcID.SKELETAL_MYSTIC);
-        bosses.add(NpcID.SKELETAL_MYSTIC_7605);
-        bosses.add(NpcID.SKELETAL_MYSTIC_7606);
         bosses.add(NpcID.GREAT_OLM_RIGHT_CLAW);
         bosses.add(NpcID.GREAT_OLM_RIGHT_CLAW_7553);
         // TODO: add vangs? might be worth adding an event to send the HP to other players too

--- a/src/main/java/com/example/enemydata/Enemy.java
+++ b/src/main/java/com/example/enemydata/Enemy.java
@@ -74,6 +74,17 @@ public abstract class Enemy implements IEnemy {
         bosses.add(NpcID.TUMEKENS_WARDEN_11762);
 
         bosses.add(NpcID.ABYSSAL_PORTAL);
+        bosses.add(NpcID.VASA_NISTIRIO);
+        bosses.add(NpcID.LIZARDMAN_SHAMAN);
+        bosses.add(NpcID.LIZARDMAN_SHAMAN_6767);
+        bosses.add(NpcID.LIZARDMAN_SHAMAN_7573);
+        bosses.add(NpcID.LIZARDMAN_SHAMAN_7574);
+        bosses.add(NpcID.LIZARDMAN_SHAMAN_7744);
+        bosses.add(NpcID.LIZARDMAN_SHAMAN_7745);
+        bosses.add(NpcID.LIZARDMAN_SHAMAN_8565);
+        bosses.add(NpcID.SKELETAL_MYSTIC);
+        bosses.add(NpcID.SKELETAL_MYSTIC_7605);
+        bosses.add(NpcID.SKELETAL_MYSTIC_7606);
         bosses.add(NpcID.GREAT_OLM_RIGHT_CLAW);
         bosses.add(NpcID.GREAT_OLM_RIGHT_CLAW_7553);
         // TODO: add vangs? might be worth adding an event to send the HP to other players too

--- a/src/main/java/com/example/enemydata/Enemy.java
+++ b/src/main/java/com/example/enemydata/Enemy.java
@@ -75,13 +75,8 @@ public abstract class Enemy implements IEnemy {
 
         bosses.add(NpcID.ABYSSAL_PORTAL);
         bosses.add(NpcID.VASA_NISTIRIO);
-        bosses.add(NpcID.LIZARDMAN_SHAMAN);
-        bosses.add(NpcID.LIZARDMAN_SHAMAN_6767);
         bosses.add(NpcID.LIZARDMAN_SHAMAN_7573);
         bosses.add(NpcID.LIZARDMAN_SHAMAN_7574);
-        bosses.add(NpcID.LIZARDMAN_SHAMAN_7744);
-        bosses.add(NpcID.LIZARDMAN_SHAMAN_7745);
-        bosses.add(NpcID.LIZARDMAN_SHAMAN_8565);
         bosses.add(NpcID.SKELETAL_MYSTIC);
         bosses.add(NpcID.SKELETAL_MYSTIC_7605);
         bosses.add(NpcID.SKELETAL_MYSTIC_7606);

--- a/src/main/java/com/example/enemydata/cox/CoxEnemy.java
+++ b/src/main/java/com/example/enemydata/cox/CoxEnemy.java
@@ -23,6 +23,17 @@ public class CoxEnemy extends Enemy {
         bosses = new HashSet<>();
 
         enemies.put(NpcID.ABYSSAL_PORTAL, Portal::new);
+        enemies.put(NpcID.SKELETAL_MYSTIC, SkeletalMystic::new);
+        enemies.put(NpcID.SKELETAL_MYSTIC_7605, SkeletalMystic::new);
+        enemies.put(NpcID.SKELETAL_MYSTIC_7606, SkeletalMystic::new);
+        enemies.put(NpcID.LIZARDMAN_SHAMAN, LizardmanShaman::new);
+        enemies.put(NpcID.LIZARDMAN_SHAMAN_7573, LizardmanShaman::new);
+        enemies.put(NpcID.LIZARDMAN_SHAMAN_7574, LizardmanShaman::new);
+        enemies.put(NpcID.LIZARDMAN_SHAMAN_6767, LizardmanShaman::new);
+        enemies.put(NpcID.LIZARDMAN_SHAMAN_7744, LizardmanShaman::new);
+        enemies.put(NpcID.LIZARDMAN_SHAMAN_7745, LizardmanShaman::new);
+        enemies.put(NpcID.LIZARDMAN_SHAMAN_8565, LizardmanShaman::new);
+        enemies.put(NpcID.ROCKS_7565, VasaNistirio::new);
         enemies.put(NpcID.GREAT_OLM_RIGHT_CLAW, OlmMageHand::new);
         enemies.put(NpcID.GREAT_OLM_RIGHT_CLAW_7553, OlmMageHand::new);
     }

--- a/src/main/java/com/example/enemydata/cox/CoxEnemy.java
+++ b/src/main/java/com/example/enemydata/cox/CoxEnemy.java
@@ -26,13 +26,8 @@ public class CoxEnemy extends Enemy {
         enemies.put(NpcID.SKELETAL_MYSTIC, SkeletalMystic::new);
         enemies.put(NpcID.SKELETAL_MYSTIC_7605, SkeletalMystic::new);
         enemies.put(NpcID.SKELETAL_MYSTIC_7606, SkeletalMystic::new);
-        enemies.put(NpcID.LIZARDMAN_SHAMAN, LizardmanShaman::new);
         enemies.put(NpcID.LIZARDMAN_SHAMAN_7573, LizardmanShaman::new);
         enemies.put(NpcID.LIZARDMAN_SHAMAN_7574, LizardmanShaman::new);
-        enemies.put(NpcID.LIZARDMAN_SHAMAN_6767, LizardmanShaman::new);
-        enemies.put(NpcID.LIZARDMAN_SHAMAN_7744, LizardmanShaman::new);
-        enemies.put(NpcID.LIZARDMAN_SHAMAN_7745, LizardmanShaman::new);
-        enemies.put(NpcID.LIZARDMAN_SHAMAN_8565, LizardmanShaman::new);
         enemies.put(NpcID.ROCKS_7565, VasaNistirio::new);
         enemies.put(NpcID.GREAT_OLM_RIGHT_CLAW, OlmMageHand::new);
         enemies.put(NpcID.GREAT_OLM_RIGHT_CLAW_7553, OlmMageHand::new);

--- a/src/main/java/com/example/enemydata/cox/LizardmanShaman.java
+++ b/src/main/java/com/example/enemydata/cox/LizardmanShaman.java
@@ -1,0 +1,19 @@
+package com.example.enemydata.cox;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.NPC;
+
+@Slf4j
+public class LizardmanShaman extends CoxEnemy {
+    public LizardmanShaman(NPC npc, boolean isCm, int partySize, int maxCombat, int maxHp) {
+        super(npc, isCm, partySize, maxCombat, maxHp, 190, 130, 210, 58, 62, 102, 160, 150);
+    }
+
+    @Override
+    public boolean queueDamage(int damage) {
+        shouldDraw = super.queueDamage(damage);
+        log.debug("current hp: {} queued damage: {} should draw: {}", current_health, queuedDamage, shouldDraw);
+        return shouldDraw;
+    }
+
+}

--- a/src/main/java/com/example/enemydata/cox/SkeletalMystic.java
+++ b/src/main/java/com/example/enemydata/cox/SkeletalMystic.java
@@ -1,0 +1,20 @@
+package com.example.enemydata.cox;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.NPC;
+
+@Slf4j
+public class SkeletalMystic extends CoxEnemy {
+    public SkeletalMystic(NPC npc, boolean isCm, int partySize, int maxCombat, int maxHp) {
+        super(npc, isCm, partySize, maxCombat, maxHp, 160, 140, 187, 85, 50, 85, 155, 75);
+    }
+
+    @Override
+    public boolean queueDamage(int damage) {
+        shouldDraw = super.queueDamage(damage);
+
+        log.debug("current hp: {} queued damage: {} should draw: {}", current_health, queuedDamage, shouldDraw);
+        return shouldDraw;
+    }
+
+}

--- a/src/main/java/com/example/enemydata/cox/VasaNistirio.java
+++ b/src/main/java/com/example/enemydata/cox/VasaNistirio.java
@@ -1,0 +1,19 @@
+package com.example.enemydata.cox;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.NPC;
+
+@Slf4j
+public class VasaNistirio extends CoxEnemy {
+    public VasaNistirio(NPC npc, boolean isCm, int partySize, int maxCombat, int maxHp) {
+        super(npc, isCm, partySize, maxCombat, maxHp, 300, 1, 175, 0, 0, 170, 190, 40);
+    }
+
+    @Override
+    public boolean queueDamage(int damage) {
+        shouldDraw = super.queueDamage(damage);
+        log.debug("current hp: {} queued damage: {} should draw: {}", current_health, queuedDamage, shouldDraw);
+        return shouldDraw;
+    }
+
+}


### PR DESCRIPTION
Added death indicators for Shamans, Vasa, and Mystics. I can clean up some of the shaman IDs if you want since I didn't really spend a lot of time figuring out which are used in CoX and which aren't. 

The rocks NPC ID is what Vasa spawns in as.

Tested in both regular solos and CM trio